### PR TITLE
[codex] Support EDITOR commands with arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ deno install --global --allow-env --allow-read --allow-write --allow-run --force
 
 We use environment variables for configuration.
 
-- `$EDITOR` - a path to an editor to open cloned repository.
+- `$EDITOR` - a path to an editor to open cloned repository. Arguments are
+  supported too, for example `zed --wait`.
 - `$SRC_DIR` - a path to a root directory for sources.
 
 ## License

--- a/mod.ts
+++ b/mod.ts
@@ -13,6 +13,82 @@ const runCommand: CommandRunner = async (command, args) => {
   return success;
 };
 
+function parseCommandLine(input: string) {
+  const parts: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | undefined;
+  let escaping = false;
+  let tokenStarted = false;
+
+  const pushCurrent = () => {
+    if (!tokenStarted) {
+      return;
+    }
+
+    parts.push(current);
+    current = "";
+    tokenStarted = false;
+  };
+
+  for (const char of input) {
+    if (escaping) {
+      current += char;
+      tokenStarted = true;
+      escaping = false;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+        continue;
+      }
+
+      if (quote === '"' && char === "\\") {
+        escaping = true;
+        tokenStarted = true;
+        continue;
+      }
+
+      current += char;
+      tokenStarted = true;
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      quote = char;
+      tokenStarted = true;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      pushCurrent();
+      continue;
+    }
+
+    if (char === "\\") {
+      escaping = true;
+      tokenStarted = true;
+      continue;
+    }
+
+    current += char;
+    tokenStarted = true;
+  }
+
+  if (escaping) {
+    throw new Error("Environment variable 'EDITOR' ends with an escape.");
+  }
+
+  if (quote) {
+    throw new Error("Environment variable 'EDITOR' has an unterminated quote.");
+  }
+
+  pushCurrent();
+
+  return parts;
+}
+
 export function expandHomeDir(input: string, homeDir?: string) {
   if (!homeDir) {
     return input;
@@ -65,14 +141,21 @@ export async function openEditor(
   dest: string,
   runner: CommandRunner = runCommand,
 ) {
-  if (!editor) {
+  if (!editor.trim()) {
+    console.log("Environment variable 'EDITOR' is empty.");
+    return;
+  }
+
+  const [command, ...editorArgs] = parseCommandLine(editor);
+
+  if (!command) {
     console.log("Environment variable 'EDITOR' is empty.");
     return;
   }
 
   console.log(`Open '${dest}' in '${editor}'...`);
 
-  if (!await runner(editor, [dest])) {
+  if (!await runner(command, [...editorArgs, dest])) {
     throw new Error("Failed to open editor.");
   }
 }

--- a/test.ts
+++ b/test.ts
@@ -108,6 +108,52 @@ Deno.test("openEditor invokes the configured editor", async function () {
   });
 });
 
+Deno.test("openEditor supports editor arguments from EDITOR", async function () {
+  let received:
+    | {
+      command: string;
+      args: string[];
+    }
+    | undefined;
+
+  const runner: CommandRunner = (command, args) => {
+    received = { command, args };
+    return Promise.resolve(true);
+  };
+
+  await openEditor("zed --wait", "/tmp/project", runner);
+
+  assertEquals(received, {
+    command: "zed",
+    args: ["--wait", "/tmp/project"],
+  });
+});
+
+Deno.test("openEditor supports quoted executable paths", async function () {
+  let received:
+    | {
+      command: string;
+      args: string[];
+    }
+    | undefined;
+
+  const runner: CommandRunner = (command, args) => {
+    received = { command, args };
+    return Promise.resolve(true);
+  };
+
+  await openEditor(
+    '"/Applications/Zed Preview.app/Contents/MacOS/zed" --wait',
+    "/tmp/project",
+    runner,
+  );
+
+  assertEquals(received, {
+    command: "/Applications/Zed Preview.app/Contents/MacOS/zed",
+    args: ["--wait", "/tmp/project"],
+  });
+});
+
 Deno.test("openEditor throws when the editor command fails", async function () {
   await assertRejects(
     () => openEditor("code", "/tmp/project", () => Promise.resolve(false)),


### PR DESCRIPTION
## Summary
- parse `EDITOR` into executable plus arguments before launching the editor
- support quoted executable paths and keep the repository path as the final argument
- add regression tests and document `EDITOR` values such as `zed --wait`

## Why
Opening the cloned repository failed when `EDITOR` contained an executable with arguments, because the whole string was treated as the command name instead of being split into argv.

## Validation
- `deno test --allow-read --allow-write test.ts`
- `deno lint mod.ts test.ts clone.ts`